### PR TITLE
Fix broken link to selfhosting instructions

### DIFF
--- a/templates/instances/index.html
+++ b/templates/instances/index.html
@@ -72,7 +72,7 @@
         {{ _("Not finding what you want?") }}
 
         <p class="has-text-weight-bold">
-            <a href="https://docs.joinbookwyrm.com/installing-in-production.html" target="_blank">
+            <a href="https://docs.joinbookwyrm.com/install-prod.html" target="_blank">
                 {{ _("Run your own BookWyrm community") }}</a>
             &middot;
             <a href="https://www.patreon.com/posts/64768354" target="_blank">


### PR DESCRIPTION
Just noticed that `installing-in-production.html` now seems to be called `install-prod.html`! Wouldn't want to put off potential selfhosters :wink: