### PR TITLE
Update index.html body to reference Open Collective

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -204,7 +204,7 @@
                     <strong>BookWyrm</strong> is collaborative, anti-corporate software maintained by <a href='https://www.mousereeve.com/'>Mouse Reeve</a>.
                 </p>
                 <p>
-                    Support BookWyrm on <a href='https://www.patreon.com/bookwyrm' target='_blank'>Patreon</a>.
+                    Support BookWyrm on <a href='https://opencollective.com/bookwyrm' target='_blank'>Open Collective</a> or <a href='https://www.patreon.com/bookwyrm' target='_blank'>Patreon</a>.
                 </p>
             </div>
             <div class="column">


### PR DESCRIPTION
Update one of three places where the home page references financial support to include Open Collective page for project. There are two other places on the home page that should be updated: the footer icons and the Support header page which could either be a drop down that lists Patreon and OC or just directs to a support landing page that points to both