### PR TITLE
Add scheduled GitHub action to build and deploy

### DIFF
--- a/.github/workflows/update-and-deploy.yml
+++ b/.github/workflows/update-and-deploy.yml
@@ -1,0 +1,31 @@
+name: Update and deploy
+
+on:
+  schedule:
+    # run at 3.15am every day
+    - cron: 15 3 * * *
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Compile site
+        run: ./bw-dev site:compile
+      - name: Deploy to server
+        id: deploy
+        uses: Pendect/action-rsyncer@v1.1.0
+        env:
+          DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
+        with:
+          flags: '-avzr --delete'
+          options: ''
+          ssh_options: ''
+          src: 'site/'
+          dest: 'mouse@docs.joinbookwyrm.com:/var/www/join-bookwyrm/html'

--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ This command will extract the translation keys from the `.html` files stored in 
 ```
 
 This second command will compile the `.PO` file into the corresponding `.MO` file.
+
+### Adding a new BookWyrm instance
+
+To add a BookWyrm instance to the list at [/instances](https://joinbookwyrm.com/instances/)
+
+1. Fork this repository
+2. Update the list of instance URLs in generate.py (being careful to include a trailing slash)
+3. Run `./bw_dev site:compile`
+4. Confirm the instance appears by running `./bw_dev site:serve`
+5. Send in a pull request

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ To add a BookWyrm instance to the list at [/instances](https://joinbookwyrm.com/
 
 1. Fork this repository
 2. Update the list of instance URLs in generate.py (being careful to include a trailing slash)
-3. Run `./bw_dev site:compile`
-4. Confirm the instance appears by running `./bw_dev site:serve`
+3. Run `./bw-dev site:compile`
+4. Confirm the instance appears by running `./bw-dev site:serve`
 5. Send in a pull request


### PR DESCRIPTION
- Added instructions for adding new BookWyrm instances to the README
- added a new github action that runs every day to build and deploy the site

Note that the github action does not push the updated files to the repository, so it is possible that a regression of sorts might occur if a commit is pushed to the repo without running `./bw-dev site:compile` -- older stats and outdated instance info might be displayed (at least till the next day). But I think this is not a big deal since it'll be for at most a day, and committing new changes daily to the repo will make the repo rather large.

I cannot and have not fully tested the GitHub action, but I think it should work.