### PR TITLE
Fixing ES translation

### DIFF
--- a/locale/es_ES/LC_MESSAGES/messages.po
+++ b/locale/es_ES/LC_MESSAGES/messages.po
@@ -146,7 +146,7 @@ msgstr "Documentación"
 
 #: templates/layout.html:70 templates/layout.html:73
 msgid "<strong>BookWyrm</strong> is collaborative, anti-corporate software maintained by <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
-msgstr "<strong>BookWyrm</strong> es un software colaborativo, anti cooperativo mantenido por <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
+msgstr "<strong>BookWyrm</strong> es un software colaborativo, anti corporativo mantenido por <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
 
 #: templates/layout.html:73 templates/layout.html:76
 msgid "Support BookWyrm on <a href='https://www.patreon.com/bookwyrm' target='_blank'>Patreon</a>."


### PR DESCRIPTION
"cooperativo" means cooperative, which is not the intended meaning in this string, so the correct translation here is "corporativo" which means corporate (as in anti-corporate)