### PR TITLE
Instances json "API"

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -97,6 +97,13 @@ if __name__ == "__main__":
         ["get-involved/index.html", lambda: {}],
     ]
 
+    print("  Generating API endpoint")
+    with open(
+        f"site/instances.json", "w+", encoding="utf-8"
+    ) as json_file:
+        json_file.write(json.dumps(instances))
+    print("")  # newline
+
     for locale in i18n.locales_metadata:
         i18n.setLocale(locale["code"])
 

--- a/generate.py
+++ b/generate.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 
     print("  Generating API endpoint")
     with open(
-        f"site/instances.json", "w+", encoding="utf-8"
+        "site/instances.json", "w+", encoding="utf-8"
     ) as json_file:
         json_file.write(json.dumps(instances))
     print("")  # newline

--- a/generate.py
+++ b/generate.py
@@ -98,9 +98,7 @@ if __name__ == "__main__":
     ]
 
     print("  Generating API endpoint")
-    with open(
-        "site/instances.json", "w+", encoding="utf-8"
-    ) as json_file:
+    with open("site/instances.json", "w+", encoding="utf-8") as json_file:
         json_file.write(json.dumps(instances))
     print("")  # newline
 


### PR DESCRIPTION
I’ve added a minor tweak to the generator script which will also write a `instances.json` file in order for e.g. apps to provide the same list of instances as the website.
I hope that is okey. Otherwise I’ll host that myself, but I thought it would be nice to have on the "main" join website.