### PR TITLE
fix spanish typo

### DIFF
--- a/locale/es_ES/LC_MESSAGES/messages.po
+++ b/locale/es_ES/LC_MESSAGES/messages.po
@@ -146,7 +146,7 @@ msgstr "Documentación"
 
 #: templates/layout.html:70 templates/layout.html:73
 msgid "<strong>BookWyrm</strong> is collaborative, anti-corporate software maintained by <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
-msgstr "<strong>BookWyrm</strong> es un software colaborativo, anti cooperativo mantenido por <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
+msgstr "<strong>BookWyrm</strong> es un software colaborativo, anticorporativo mantenido por <a href='https://www.mousereeve.com/'>Mouse Reeve</a>."
 
 #: templates/layout.html:73 templates/layout.html:76
 msgid "Support BookWyrm on <a href='https://www.patreon.com/bookwyrm' target='_blank'>Patreon</a>."


### PR DESCRIPTION
fix small but very important typo. It changes the meaning completly!
Now the translation means that it's a anti-cooperative software!